### PR TITLE
add initial site superstructure

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -1,0 +1,7 @@
+# Code Review During Development
+
+## Developer Profiles
+* [Single Developer](./flowcharts/lonecoder.md)
+
+## Resources
+* [Glossary](./glossary.md)

--- a/site/content/flowcharts/lonecoder.md
+++ b/site/content/flowcharts/lonecoder.md
@@ -1,0 +1,10 @@
+## Single Developer Workflow
+
+Here's a high-level view of a workflow you can follow as
+a single developer that would like to make code review
+part of your development process.
+
+![image of single developer workflow](../../static/lone-coder-code-review.png)
+
+To read about this workflow in detail, please see
+[single developer process](../recipes/lonecoder.md)

--- a/site/content/glossary.md
+++ b/site/content/glossary.md
@@ -1,0 +1,3 @@
+# glossary
+
+definitions of terms used throughout this site


### PR DESCRIPTION
adds an initial draft of what the structure of the site will
look like.

The basic idea is a landing page with two sections,
"developer profiles" and "resources".
The "developer profiles" will essentially be a table of contents
with links that take readers to flowcharts for each developer profile,
e.g. our single developer that we're iterating on now.

Then from the flowcharts, a reader can click on sections
to read the detailed descriptions we will have in "recipes".

For now the "resources" section just contains the glossary.

- add site/content/_index.md

  with a "developer profiles" section that points to
  the "single developer" flowchart,
  and a separate "resources" section with a link to the glossary

- add ./site./content/flowcharts/ with lonecoder.md
  + this will be the "content section" (Hugo lingo)
    that contains all the graphic depictions of the
    different workflows.

    A site visitor to the top-level

- add ./site/content/glossary.md