### PR TITLE
change a heading in content/_index.md

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -29,8 +29,8 @@ graph TD;
   E --> B
 {{< /mermaid >}}
 
-## Developer Profiles
-* [Single Developer](flowcharts/lonecoder)
+## Tutorials
+* [Getting Started with Code Review](flowcharts/lonecoder)
 
 ## Resources
 * [Glossary](glossary)


### PR DESCRIPTION
as discussed at last meeting (17)

rename "# Developer Profiles" -> "# Tutorials" and change "Single Developer" bullet to "Getting Started with Code Review"

I felt like we agreed this was a good idea, wanted to go ahead and open discussion on a PR. 

I went with "Getting Started" since I'm thinking along the lines of docs where the tutorial would be the highest level intro, and you could have more detailed "how-to" guides (maybe that is where specifics on different "workflows" for single devs v RSE teams could go?)