### PR TITLE
Touch up the 'Perform code review' section

### DIFF
--- a/site/content/recipes/perform_code_review.md
+++ b/site/content/recipes/perform_code_review.md
@@ -1,5 +1,14 @@
 # Perform code review
 
+The previous phases have all be about setting the best foundation possible for
+the code review. Now it is time to execute and reap the benefits of code review.
+We will walk through the following steps:
+
+1. [Code author communicates code and context](#code-author-communicates-code-and-context)
+1. [Reviewer reviews code](#reviewer-reviews-code)
+1. [Author and reviewer meet](#author-and-reviewer-meet)
+1. [Author makes changes](#code-author-implements-changes)
+
 ## Code author communicates code and context
 
 The first step initiating the actual code review phase is for the code author to

--- a/site/content/recipes/perform_code_review.md
+++ b/site/content/recipes/perform_code_review.md
@@ -60,9 +60,9 @@ use it or are used by it.
 > **How to share code?**
 > Ideally, revisions of your research software should be available from
 > development platforms like GitHub, GitLab or Bitbucket. Simply give
-> the reviewer a permalink (see figure ??) or a commit SHA-1 and
+> the reviewer a permalink (see figure below) or a commit SHA-1 and
 > relevant line numbers. This is the preferred option as it gives
-> reviewers the opporunity to navigate the whole codebase. Another
+> reviewers the opportunity to navigate the whole codebase. Another
 > option is [GitHub gists](https://gist.github.com/). If you send
 > your code by email, make sure to share the relevant files and clearly
 > identify the version you are sharing.
@@ -71,14 +71,6 @@ use it or are used by it.
 
 
 > callout here about diff workflows "merge workflow", "github workflow"
-
-      - If you are going down an async review route, then providing the reviewer with a merge/pull request will be very helpful here
-    - It might not be possible to share your code openly like this, or you may not be set up with version control yet
-      - in that case, consider using something like [GitHub gists](https://gist.github.com/) to share your code
-      - as a last resort, share your code snippet as an attachement to email or link to a file hosting location
-    - Should be done a few days before the review meeting so that the reviewer has time to look at it. Exact timing should be discussed and MAO.
-    - If your code has a complex environment, it might be desirable to share a containerised version of your code/software through somethign like Binder
-        - mention CODECHECK as perhaps a better option for this kind of higher level check of your code
 
 
 ## Reviewer reviews code

--- a/site/content/recipes/perform_code_review.md
+++ b/site/content/recipes/perform_code_review.md
@@ -54,7 +54,7 @@ When you share a piece of code with reviewers, attach a
 description of its context. Explain what problem the code solves,
 and how it solves it. Make clear the constraints you had to work with.
 If the code is part of a larger codebase, describe how it fits within
-the bigger logic and explicit the relationships with other parts that
+the bigger logic and make explicit the relationships with other parts that
 use it or are used by it.
 
 > **How to share code?**
@@ -66,12 +66,10 @@ use it or are used by it.
 > option is [GitHub gists](https://gist.github.com/). If you send
 > your code by email, make sure to share the relevant files and clearly
 > identify the version you are sharing.
-
-![To get a link to a particular line (permalink) on GitHub, click on the line number on the left hand side](/dev-review/images/github_permalink.png "To get a link to a particular line (permalink) on GitHub, click on the line number on the left hand sise. Most development platforms can generate links to a particular line, for a particular revision.")
-
-
-> callout here about diff workflows "merge workflow", "github workflow"
-
+> ![To get a link to a particular line (permalink) on GitHub, click on the line number on the left hand side](/dev-review/images/github_permalink.png "To get a link to a particular line (permalink) on GitHub, click on the line number on the left hand side. Most development platforms can generate links to a particular line, for a particular revision.")
+> If you are performing an asynchronous review (see callout at top of [Author
+> and reviewer meet](#author-and-reviewer-meet)) then giving your reviewer a
+> link to a pull/merge request is also an effective sharing mechanism.
 
 ## Reviewer reviews code
 
@@ -126,6 +124,21 @@ These key points can form the focus for when you and the author meet, as
 described in the next section.
 
 ## Author and reviewer meet
+
+Before describing the meeting phase of the code review, it is worth mentioning
+that there is an alternate technique for code review.
+
+> **Asynchronous Review:** The most common form of code review in industry is
+> done _asynchronously_ through platforms like GitHub and GitLab. Authors of
+> changes submit what are called _merge_ or _pull requests_ into the main or
+> development branch of a code repository. Reviewers then leave their comments
+> through the web interface, directly in the context of the changes made.
+> The author addresses the comments, and when a consensus is reached, the changes
+> are merged or rejected. This all happens through the web interface with no
+> real time or face-to-face interaction. While this can be an effective form of
+> review for projects, we feel strongly that researchers with less experience of code
+> review benefit more from the meeting-based approach outlined by this website.
+
 - key points:
   -  there are two ways to do code review: synchronous/in-person, and asynchronous
   -  while there is not much existing research, what does exist suggests that for research code review, the process should include face-to-face, synchronous component [Wilson 2015]

--- a/site/content/recipes/perform_code_review.md
+++ b/site/content/recipes/perform_code_review.md
@@ -116,8 +116,8 @@ First of all, keep the authors' objectives in mind.
 To achieve this, begin your review by refreshing your memory about what you and
 the author discussed when you met initially.
 The second key element is to work from a checklist.
-We provide a checklist [here](../guidelines/points-to-check-for-reviewers.md).
-Please see also the additional resources on the [References and Related Work](../refs-related.md) page.
+We provide a checklist [here](../../guidelines/points-to-check-for-reviewers).
+Please see also the additional resources on the [References and Related Work](../../refs-related) page.
 Of course, no checklist can perfectly capture all the dimensions of research
 code review.
 Our goal in providing a checklist is to give beginners somewhere to start, and
@@ -148,35 +148,66 @@ that there is an alternate technique for code review.
 > review for projects, we feel strongly that researchers with less experience of code
 > review benefit more from the meeting-based approach outlined by this website.
 
-- key points:
-  -  there are two ways to do code review: synchronous/in-person, and asynchronous
-  -  while there is not much existing research, what does exist suggests that for research code review, the process should include face-to-face, synchronous component [Wilson 2015]
-  -  This is because there are such different backgrounds that can go into code review and both the author and reviewer need to make sure they are understanding each other
-- A good way to open up this meeting might be for the author and reviewer to go over the scientific context for the code review
-- Reviewer drives review according to their notes. They discuss the code by giving direct feedback or asking questions challenging the code's design, implementation and documentation.
-- Author responds to reviewer's comments and questions. They describe the structure, explain implementation, justify decisions.
-- Live reviews help build trust and understand the other person's mindset.
-- This is a conversation in which the code author has the opportunity to talk about their code out loud. By asking questions, expressing opinions and challenging assumptions a code reviewer triggers new ideas and different perspectives.
-  - > [name=David] maybe "suggesting alternatives" or something a bit less aggressive than  "challenging assumptions"?
-- Predefined objectives should be kept in mind. Conversation can be powerful but should be kept on a tight leash. It's okay for anyone to stop the conversation and say they feel it is losing focus. In this case it is time to move to the next topic.
--
-- A code review is not an evaluation of the author's worth as a programmer. Throughout the review, participants should keep in mind
-  -  Differences in levels of experience.
-  -  Differences in scientific and programming backgrounds.
-  -  Code quality is often subjective and context dependent.
-  -  *More?*...
-  -  
-- By opening their work for feedback, code authors make *themselves* vulnerable. This vulnerability must be taken into account and respected by reviewers at all times. Reviewers must take caution in expressing feedback and opinions. Authors must respect reviewer's comments and questions.
-- Reviewing can be mentally demanding. It can be difficult for a reviewer to be mindful of how they phrase feedback at all times. Therefore authors should also try not to take feedback personally. This is especially true for written, asynchronous reviews.
-- Example of questionable reviewer's feedback:
-  - You should rename this function
-  - This function should be renamed
-- Examples of good reviewer's feedback
-  - I think this function's name is misleading
-  - This function's name didn't help me understand what it does.
-- Meeting should be kept short, under 60', 45' being a good target duration in most cases. This is to avoid fatigue. Two 45' review meetings will likely be more effective than a single 90' meeting. This can, however, be decided on the spot or ahead of the meeting.
-- Time will likely run out. It is possible than conversations on some of the points could have been shorter. It is also possible that the corresponding points needed to be discussed in details for reasons only made clear during teh review itself. In any case, both authors and reviewers can choose to meet again to continue the review.
+While there is not much existing research, what does exist suggests that for
+research code review, the process should include face-to-face, synchronous
+component \[Petre and Wilson 2015\]. This is because there can be a wide
+disparity in backgrounds for those performing the code review, and both the
+author and reviewer need to make sure they are understanding each other.
+
+A good way to open up this meeting might be for the author to go over the
+scientific context for the code again and the objectives, to remind the reviewer
+of the bigger picture. However, after this, the reviewer should 'drive' the
+meeting according to their notes. The reviewer discusses the code by giving
+direct feedback or asking questions about the code's design, implementation, and
+documentation. But remember, this is a discussion, so the author responds to
+reviewer's comments and questions, explaining implementation and justifying
+decisions.
+
+Live reviews help build trust and understand the other person's mindset. This is
+a conversation in which the code author has the opportunity to talk about their
+code out loud. By asking questions, expressing opinions and suggesting alternatives, a code
+reviewer triggers new ideas and different perspectives. Predefined objectives
+should be kept in mind. Conversation can be powerful but should be kept on a
+tight leash. It's okay for anyone to stop the conversation and say they feel it
+is losing focus. In this case it is time to move to the next topic.
+
+A code review is not an evaluation of the author's worth as a programmer.
+Throughout the review, participants should keep in mind:
+- Differences in levels of experience.
+- Differences in scientific and programming backgrounds.
+- Code quality is often subjective and context dependent.
+
+By opening their work for feedback, code authors make *themselves* vulnerable.
+This vulnerability must be taken into account and respected by reviewers at all
+times, so they should be mindful of how they are raising feedback. A helpful
+technique is to express personal opinions rather than make imperative
+statements. Take this example about suggesting a function should be renamed:
+
+| Imperative statements (risky) | Personal opinion (safer) |
+|-------------------------------|--------------------------|
+| "You should rename this function" | "I think this function's name could be improved" |
+| "This function should be renamed" | "This function's name didn't help me understand what it does." |
+
+Conversely, reviewing is mentally demanding. It can be difficult for a reviewer
+to be mindful of how they phrase feedback at all times. Therefore authors should
+also try not to take feedback personally. This is especially true for written,
+asynchronous reviews.
+
+Meeting should be kept short, under 60', 45' being a good target in most cases.
+This is to avoid fatigue. Two 45' review meetings will likely be more effective
+than a single 90' meeting. This can, however, be decided on the spot or ahead of
+the meeting. Time will likely run out. It is possible than conversations on some
+of the points could have been shorter. It is also possible that the
+corresponding points needed to be discussed in details for reasons only made
+clear during the review itself. In any case, both authors and reviewers can
+choose to meet again to continue the review.
 
 ## Code author implements changes
+
+Once the reviewer has communicated the changes they think the author should
+make, it is time for the author to review these suggestions on their own and
+attempt to make the changes. If the author thinks the changes have met their
+objectives, then the code review process comes to a close. Otherwise, the author
+might return to the reviewer and ask if further review of their code is possible.
 
 ## Rinse and repeat


### PR DESCRIPTION
Some minor formatting fixes, but also I converted the bullet points into prose for the 'Author and reviewer meet' section. I know that we said no more major changes to the website, but I think this something nice to have.